### PR TITLE
Repoint GHCR builder image to BOOST-Working-Group org

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: carbondirect/boost/boost-builder
+  IMAGE_NAME: boost-working-group/boost/boost-builder
 
 jobs:
   build-and-push:


### PR DESCRIPTION
## Summary

The `build-deploy` workflow currently fails on container pull — `ghcr.io/carbondirect/boost/boost-builder:latest` is no longer accessible from this repo's workflows after the org migration.

This PR updates only `docker-image.yml`'s `IMAGE_NAME` env to publish the builder image under `ghcr.io/boost-working-group/boost/boost-builder`. Merging triggers the docker-image workflow (path filter matches `.github/workflows/docker-image.yml`), which publishes the image at the new path.

A follow-up PR will update consumer workflows (`build-deploy.yml`, `build-dev-docs.yml`, `release.yml`) to pull from the new path. Done in two steps so the consumers don't try to pull before the new image exists.

## Verification

- Last successful build-deploy run: 2025-09-04 (used the carbondirect image)
- Manual `workflow_dispatch` of build-deploy on 2026-05-05 (run 25408237982) failed at "Initialize containers" with `Docker pull failed with exit code 1`

## Test plan

- [ ] Merge PR
- [ ] Confirm `docker-image` workflow run succeeds and pushes `ghcr.io/boost-working-group/boost/boost-builder:latest`
- [ ] Open follow-up PR for consumer workflow updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)