### PR TITLE
Pin bikeshed<6 in Dockerfile to restore image build

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y \
 
 # Upgrade pip and install Python dependencies
 RUN pip install --upgrade pip && \
-    pip install bikeshed jsonschema pydantic[email] requests pycairo
+    pip install 'bikeshed<6' jsonschema pydantic[email] requests pycairo
 
 # Initialize Bikeshed spec database (this takes time, so cache it in image)
 RUN bikeshed update


### PR DESCRIPTION
## Summary

After #286 republished the GHCR builder image at the new path, the actual `docker-image` build run failed with:

> Bikeshed now requires Python 3.12 or higher; you are on 3.10.12.

This is unrelated to the org migration — the Sep 2025 builder image was built with bikeshed 5.x, and bikeshed 6.x (released later) requires Python 3.12+, but `tools/Dockerfile` uses `ubuntu:22.04` (Python 3.10).

This PR pins `bikeshed<6` to replicate the toolchain that worked in Sep 2025. A proper modernization (Ubuntu 24.04 + Python 3.12 + PEP 668-aware venv) is out of scope here and should be a separate effort.

## Test plan

- [ ] Merge PR (path filter on `tools/Dockerfile` will trigger `docker-image` workflow)
- [ ] Confirm `docker-image` run succeeds
- [ ] Confirm `ghcr.io/boost-working-group/boost/boost-builder:latest` is published
- [ ] Then proceed with consumer-workflow refs PR (already prepared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)