### PR TITLE
Charter amendment: extend scope to timber & forest fiber (#283)

### DIFF
--- a/BOOST_Charter.org
+++ b/BOOST_Charter.org
@@ -28,11 +28,11 @@ The group will seek participation from a balanced range of stakeholders, includi
 
 * Goals
 
-The mission and goals of this Community Group are to *develop and* *maintain a robust data standard for solid biomass*. to provide a structured framework to enable the systematic collection, management, and exchange of information throughout complex supply chains and processes. The goal is to ensure accurate tracking, transparency, and compliance with sustainability criteria, facilitating the reliable transfer of essential information, including sustainability characteristics and data required for greenhouse gas (GHG) emission calculations, from the source to the end-user. This standard is intended to support the needs of organizations involved in the biomass supply chain, agencies and stakeholders in the biomass economy, and systems like Chain of Custody (CoC) software, referencing concepts from documents like the Netherlands Enterprise Agency, /“Guidance Chain of/ /Custody: Sustainability Criteria for Solid Biomass for Energy/ /Applications.”/ and related standards such as those from Sustainable Biomass Program , International Organization for Standardization, Sustainable Forestry Initiative, the Forest Stewardship Council, and the Roundtable on Sustainable Biomaterials
+The mission and goals of this Community Group are to *develop and* *maintain a robust data standard for forest-derived materials* — spanning woody biomass for energy, sawn timber and engineered wood products, and forest fiber for pulp, paper, and bio-based manufacturing — to provide a structured framework to enable the systematic collection, management, and exchange of information throughout complex supply chains and processes. The goal is to ensure accurate tracking, transparency, and compliance with sustainability criteria, facilitating the reliable transfer of essential information, including sustainability characteristics and data required for greenhouse gas (GHG) emission calculations, from the source to the end-user. This standard is intended to support the needs of organizations involved in the biomass supply chain, agencies and stakeholders in the biomass economy, and systems like Chain of Custody (CoC) software, referencing concepts from documents like the Netherlands Enterprise Agency, /“Guidance Chain of/ /Custody: Sustainability Criteria for Solid Biomass for Energy/ /Applications.”/ and related standards such as those from Sustainable Biomass Program , International Organization for Standardization, Sustainable Forestry Initiative, the Forest Stewardship Council, and the Roundtable on Sustainable Biomaterials
 
 * Scope of Work
 
-The scope of work includes defining a data standard that specifies the format, structure, and relationships of data elements necessary to document and transfer information about solid biomass for energy applications within a Chain of Custody system.
+The scope of work includes defining a data standard that specifies the format, structure, and relationships of data elements necessary to document and transfer information about forest-derived materials — woody biomass for energy, sawn timber and engineered wood products, and forest fiber for pulp, paper, and bio-based manufacturing — within a Chain of Custody system.
 
 The standard shall cover the representation of key entities and their associated information as described in relevant guidance and standards, including:
 
@@ -51,6 +51,8 @@ The standard shall cover the representation of key entities and their associated
 - The standard should consider how to represent the flow of information between suppliers and recipients and the use of documentation like   sales/delivery documents.
 - Consideration of alignment or interoperability requirements with   existing data transfer systems, such as the SBP Data Transfer System  (DTS).
 
+The entity examples above derive from the original solid-biomass-for-energy guidance. For timber, engineered wood products, and forest fiber within the extended scope, the standard shall cover the analogous entities — including provenance and harvest origin, species and material attributes, transformation and processing events, and the certification claims and chain-of-custody documentation that apply to wood products (such as FSC and PEFC Chain of Custody) — with the specific entity set and its alignment to commodity-agnostic traceability frameworks determined by the group through the Decision Process.
+
 The standard should be defined in a technical format suitable for software system implementation, potentially including supporting documentation.
 
 * Out of Scope
@@ -62,11 +64,12 @@ Topics known in advance to be out of scope include:
 - Defining the requirements for establishing or operating a complete   Chain of Custody management system (these are defined in CoC standards). The standard will define the   data structure that such systems would manage and exchange.
 - Governing or approving certification schemes or their specific claims.
 - Defining the legal responsibilities of organizations (these are   determined by regulations and contractual agreements).
+- Tracking of non-forest biomass feedstocks (e.g., agricultural   residues, dedicated energy crops, or marine biomass). The standard   focuses on forest-derived materials; non-forest feedstocks are out of   scope for this charter.
 
 * Deliverables
 
 ** Specifications
-The primary deliverable will be a *Biomass Data Standard* *specification*. This specification will define the structure, format, and relationships of data elements for solid biomass chain of custody information exchange. The output format (e.g., JSON Schema, XML Schema, OWL/RDF) will be determined by the group. An estimated schedule for key deliverables (e.g., first draft, candidate recommendation) will be developed by the group.
+The primary deliverable will be the *BOOST data standard specification*. This specification will define the structure, format, and relationships of data elements for forest-derived materials chain of custody information exchange. The output format (e.g., JSON Schema, XML Schema, OWL/RDF) will be determined by the group. An estimated schedule for key deliverables (e.g., first draft, candidate recommendation) will be developed by the group.
 
 ** Non-Normative Reports
 


### PR DESCRIPTION
## Proposed charter amendment — scope extension to timber & forest fiber

Closes the drafting step of #283. This PR extends the BOOST Charter's scope from **solid biomass for energy applications** to **forest-derived materials** across three constituencies:

1. woody biomass for energy,
2. sawn timber and engineered wood products, and
3. forest fiber for pulp, paper, and bio-based manufacturing.

### Why

The current scope ("solid biomass for energy applications", Scope of Work) gates work already in motion: external circulation of the WWF–GTFT alignment review (#270), the harvest-claim validation extension-point cluster (#295), and timber-side participant recruitment. Forest-products stakeholders reading the charter today correctly conclude that timber traceability is out of scope. This amendment removes that ambiguity.

### What changed

- **Goals** and **Scope of Work** — name the three constituencies in place of "solid biomass for energy applications."
- **Scope of Work** — a new paragraph notes the existing entity examples derive from the original energy-biomass guidance, and that for timber/engineered wood/forest fiber the standard covers the analogous entities (provenance and harvest origin, species and material attributes, transformation and processing events, wood-products chain-of-custody claims including FSC/PEFC CoC) — **with the specific entity set determined by the group through the Decision Process.** The charter sets scope; it does not design the schema.
- **Out of Scope** — adds an explicit exclusion: non-forest biomass feedstocks (agricultural residues, dedicated energy crops, marine biomass) remain out of scope.
- **Deliverables** — drops "Biomass" from the deliverable title (now "BOOST data standard specification"), keeping it name-neutral.

### What did NOT change

- **No rename.** The standard remains BOOST (Biomass Open Origin Standard for Tracking). The brand-level question — whether the name should change now that scope includes timber — is deliberated **separately** under #299, and does not block this scope amendment.
- Decision Process, Chair Selection, Contribution Mechanics, and all governance sections are untouched.

### Process & timeline (per § Amendments to this Charter)

The charter requires a **30-day vote** on the proposed new charter, passing at **2/3 of votes cast**, effective the later of the proposed date or 7 days after results are announced.

| Step | Date (proposed) |
|---|---|
| Proposed charter circulated for review (this PR) | 2026-06-15 |
| WG review window — comment here or on #283 | through the WG meeting |
| WG meeting: present amendment, open the 30-day vote | **2026-06-25** (pending confirmation) |
| 30-day vote closes | ~2026-07-25 |
| Ratified charter effective (7+ days after results) | ~2026-08-01 |

This meets the #283 target of 2026-06-30 at the point of **vote opening**, not ratification.

### How to participate

- **Substantive edits to the proposed text:** comment inline on this PR or open a review.
- **Scope-level discussion / objections:** comment on #283.
- **The name question:** comment on #299 (see `project_planning/rename_decision_framework.org`).

Votes will be recorded as comments on a dedicated vote issue opened at the WG meeting; per § Decision Process, all votes must include justification.
